### PR TITLE
Install nbgitpuller

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+nbgitpuller


### PR DESCRIPTION
Needed for using this repository as the base for notebooks in other
repositories.